### PR TITLE
implement notice execution endpoint.

### DIFF
--- a/config/api.yaml
+++ b/config/api.yaml
@@ -249,3 +249,10 @@
   - search
   :prefix: payment_delivery_convert
   :fields: text,type,multi_id,delivery_id,deleted_flag,creation_date,last_modified_date,creator_id,creator_name,last_modified_by_id,last_modified_by_name
+:notice_execution:
+  :method:
+  - add
+  - count
+  - search
+  :prefix: execution_notice
+  :fields: id,success,title,content,read,creation_date,last_modified_date

--- a/lib/ne_api.rb
+++ b/lib/ne_api.rb
@@ -115,7 +115,7 @@ module NeAPI
           get_key = "data"
         when "info"
           query = nil
-        when "update", "upload", "receipted", "shipped", "labelprinted"
+        when "update", "upload", "receipted", "shipped", "labelprinted", "add"
           get_key = "result"
         when "divide"
           get_key = "receive_order_id"


### PR DESCRIPTION
config/apiymlに定義されていない実行結果お知らせのエンドポイントを追加しました。


https://developer.next-engine.com/api/api_v1_notice_execution/add
https://developer.next-engine.com/api/api_v1_notice_execution/count
https://developer.next-engine.com/api/api_v1_notice_execution/search